### PR TITLE
UserKeyServiceImpl convert function does not support EdDSA Algorithm

### DIFF
--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/UserKeyServiceImpl.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/UserKeyServiceImpl.java
@@ -177,6 +177,8 @@ public class UserKeyServiceImpl implements UserKeyService {
         try {
             if (algorithm.isRSAAlgorithm()) {
                 keyFactory = KeyFactory.getInstance("RSA");
+            } else if (algorithm.isEdDSAAlgorithm()) {
+                keyFactory = KeyFactory.getInstance("EdDSA");
             } else {
                 keyFactory = KeyFactory.getInstance("ECDSA");
             }


### PR DESCRIPTION
#What is this PR for?
See Issue #4 

## Overview or reasons
Please see Issue #4

## Tasks
- added a case for the EdDSA algorithm.

## Result
- I have tested this with a custom authenticator (i.e. one that works on local servers / non https servers) forced to use EdDSA, and confirmed that it works for EdDSA keys.