### PR TITLE
Add aaguid as a member of Assertion response to distinguish authenticator

### DIFF
--- a/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/server/VerifyCredentialResult.java
+++ b/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/server/VerifyCredentialResult.java
@@ -31,6 +31,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 @JsonInclude(NON_NULL)
 public class VerifyCredentialResult implements ServerAPIResult {
     private ServerResponse serverResponse;
+    private String aaguid;
     private String userId;
     private boolean userVerified;
     private boolean userPresent;

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/advice/RestExceptionHandler.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/advice/RestExceptionHandler.java
@@ -52,6 +52,7 @@ public class RestExceptionHandler extends ResponseEntityExceptionHandler {
                 .build();
 
         fidoServerErrorResponse.setServerResponse(serverResponse);
+        fidoServerErrorResponse.setAaguid(ex.getAaguid());
         return new ResponseEntity<>(fidoServerErrorResponse, HttpStatus.BAD_REQUEST);
     }
 

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/exception/FIDO2ServerRuntimeException.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/exception/FIDO2ServerRuntimeException.java
@@ -62,4 +62,8 @@ public class FIDO2ServerRuntimeException extends RuntimeException {
                 "RpId: " + rpId + "; UserId: " + userId);
     }
 
+    public static FIDO2ServerRuntimeException makeSignatureVerificationError(String aaguid) {
+        throw new FIDO2ServerRuntimeException(InternalErrorCode.ASSERTION_SIGNATURE_VERIFICATION_FAIL,
+                "AAGUId: " + aaguid);
+    }
 }

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/exception/FIDO2ServerRuntimeException.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/exception/FIDO2ServerRuntimeException.java
@@ -24,6 +24,7 @@ import lombok.Getter;
 public class FIDO2ServerRuntimeException extends RuntimeException {
     private static final long serialVersionUID = -2575717184560818381L;
     private final InternalErrorCode errorCode;
+    private String aaguid;
 
     public FIDO2ServerRuntimeException(InternalErrorCode errorCode) {
         this.errorCode = errorCode;
@@ -34,6 +35,12 @@ public class FIDO2ServerRuntimeException extends RuntimeException {
         this.errorCode = errorCode;
     }
 
+    public FIDO2ServerRuntimeException(InternalErrorCode errorCode, String message, String aaguid) {
+        super(message);
+        this.errorCode = errorCode;
+        this.aaguid = aaguid;
+    }
+
     public FIDO2ServerRuntimeException(InternalErrorCode errorCode, String message, Throwable cause) {
         super(message, cause);
         this.errorCode = errorCode;
@@ -42,10 +49,6 @@ public class FIDO2ServerRuntimeException extends RuntimeException {
     public FIDO2ServerRuntimeException(InternalErrorCode errorCode, Throwable cause) {
         super(cause);
         this.errorCode = errorCode;
-    }
-
-    public static FIDO2ServerRuntimeException makeInternalServerError(Throwable cause) {
-        return new FIDO2ServerRuntimeException(InternalErrorCode.INTERNAL_SERVER_ERROR, cause);
     }
 
     public static FIDO2ServerRuntimeException makeCryptoError(Throwable cause) {
@@ -60,10 +63,5 @@ public class FIDO2ServerRuntimeException extends RuntimeException {
     public static FIDO2ServerRuntimeException makeCredNotFoundUser(String rpId, String userId) {
         throw new FIDO2ServerRuntimeException(InternalErrorCode.CREDENTIAL_NOT_FOUND,
                 "RpId: " + rpId + "; UserId: " + userId);
-    }
-
-    public static FIDO2ServerRuntimeException makeSignatureVerificationError(String aaguid) {
-        throw new FIDO2ServerRuntimeException(InternalErrorCode.ASSERTION_SIGNATURE_VERIFICATION_FAIL,
-                "AAGUId: " + aaguid);
     }
 }

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/model/FIDOServerErrorResponse.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/model/FIDOServerErrorResponse.java
@@ -23,4 +23,5 @@ import lombok.Data;
 @Data
 public class FIDOServerErrorResponse {
     private ServerResponse serverResponse;
+    private String aaguid;
 }

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/AttestationServiceImpl.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/AttestationServiceImpl.java
@@ -46,7 +46,6 @@ import org.springframework.stereotype.Service;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.GeneralSecurityException;
-import java.security.cert.Certificate;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509Certificate;
@@ -118,7 +117,7 @@ public class AttestationServiceImpl implements AttestationService {
         log.info("Verify hash of RP ID with rpIdHash in authData");
         byte[] rpIdHash = Digests.sha256(rpId.getBytes(StandardCharsets.UTF_8));
         if (!Arrays.equals(attestationObject.getAuthData().getRpIdHash(), rpIdHash)) {
-            throw new FIDO2ServerRuntimeException(InternalErrorCode.RPID_HASH_NOT_MATCHED);
+            throw new FIDO2ServerRuntimeException(InternalErrorCode.RPID_HASH_NOT_MATCHED, "RP ID hash is not matched", AaguidUtil.convert(attestationObject.getAuthData().getAttestedCredentialData().getAaguid()));
         }
 
         // verify user present flag
@@ -134,7 +133,7 @@ public class AttestationServiceImpl implements AttestationService {
                 authenticatorSelection.getUserVerification() != null &&
                 authenticatorSelection.getUserVerification() == UserVerificationRequirement.REQUIRED &&
                 !attestationObject.getAuthData().isUserVerified()) {
-            throw new FIDO2ServerRuntimeException(InternalErrorCode.USER_VERIFICATION_FLAG_NOT_SET);
+            throw new FIDO2ServerRuntimeException(InternalErrorCode.USER_VERIFICATION_FLAG_NOT_SET, "User verification flag not set", AaguidUtil.convert(attestationObject.getAuthData().getAttestedCredentialData().getAaguid()));
         }
     }
 

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ResponseServiceImpl.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ResponseServiceImpl.java
@@ -300,7 +300,7 @@ public class ResponseServiceImpl extends ResponseCommonService implements Respon
         byte[] signatureBytes = Base64.getUrlDecoder().decode(serverPublicKeyCredential.getResponse().getSignature());
         boolean result = SignatureHelper.verifySignature(userKey.getPublicKey(), toBeSignedMessage, signatureBytes, userKey.getAlgorithm());
         if (!result) {
-            throw new FIDO2ServerRuntimeException(InternalErrorCode.ASSERTION_SIGNATURE_VERIFICATION_FAIL);
+            throw FIDO2ServerRuntimeException.makeSignatureVerificationError(userKey.getAaguid());
         }
     }
 

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ResponseServiceImpl.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ResponseServiceImpl.java
@@ -200,13 +200,13 @@ public class ResponseServiceImpl extends ResponseCommonService implements Respon
 
         UserKey userKey = getUserKey(serverPublicKeyCredential, rpId);
         verifyUserHandle(serverPublicKeyCredential, userKey);
-        verifyAuthDataValues(rpId, session, authData);
+        verifyAuthDataValues(rpId, session, authData,userKey.getAaguid());
         verifySignature(serverPublicKeyCredential, authDataBytes, userKey);
 
         checkSignCounter(authData, userKey);
         // return authentication processing result
         log.info("[Finish handling assertion]");
-        return createVerifyCredentialResult(authData, userKey, userKey.getAaguid());
+        return createVerifyCredentialResult(authData, userKey);
     }
 
     protected void checkCredentialId(ServerAuthPublicKeyCredential serverPublicKeyCredential, Session session) {
@@ -243,7 +243,7 @@ public class ResponseServiceImpl extends ResponseCommonService implements Respon
         if (!StringUtils.isEmpty(serverPublicKeyCredential.getResponse().getUserHandle())) {
             if (!userKey.getId().equals(serverPublicKeyCredential.getResponse().getUserHandle())) {
                 // MUST identical to uerHandle
-                throw new FIDO2ServerRuntimeException(InternalErrorCode.USER_HANDLE_NOT_MATCHED);
+                throw new FIDO2ServerRuntimeException(InternalErrorCode.USER_HANDLE_NOT_MATCHED,"User handle is not matched",userKey.getAaguid());
             }
         }
     }
@@ -258,19 +258,19 @@ public class ResponseServiceImpl extends ResponseCommonService implements Respon
         return authData;
     }
 
-    protected void verifyAuthDataValues(String rpId, Session session, AuthenticatorData authData) {
+    protected void verifyAuthDataValues(String rpId, Session session, AuthenticatorData authData, String aaguid) {
         // verify RP ID (compare with SHA256 hash or RP ID)
         log.info("Verify hash of RP ID with rpIdHash in authData");
 
         byte[] rpIdHash = Digests.sha256(rpId.getBytes(StandardCharsets.UTF_8));
         if (!Arrays.equals(authData.getRpIdHash(), rpIdHash)) {
-            throw new FIDO2ServerRuntimeException(InternalErrorCode.RPID_HASH_NOT_MATCHED);
+            throw new FIDO2ServerRuntimeException(InternalErrorCode.RPID_HASH_NOT_MATCHED, "RP ID hash is not matched", aaguid);
         }
 
         // verify user present flag
         log.info("Verify user present flag. Should be set");
         if (!authData.isUserPresent()) {
-            throw new FIDO2ServerRuntimeException(InternalErrorCode.USER_PRESENCE_FLAG_NOT_SET);
+            throw new FIDO2ServerRuntimeException(InternalErrorCode.USER_PRESENCE_FLAG_NOT_SET, "User presence flag not set.", aaguid);
         }
 
         // verify user verification
@@ -278,7 +278,7 @@ public class ResponseServiceImpl extends ResponseCommonService implements Respon
         if (session.getAuthOptionResponse().getUserVerification() != null &&
                 session.getAuthOptionResponse().getUserVerification() == UserVerificationRequirement.REQUIRED &&
                 !authData.isUserVerified()) {
-            throw new FIDO2ServerRuntimeException(InternalErrorCode.USER_VERIFICATION_FLAG_NOT_SET);
+            throw new FIDO2ServerRuntimeException(InternalErrorCode.USER_VERIFICATION_FLAG_NOT_SET, "User verification flag not set", aaguid);
         }
     }
 
@@ -300,14 +300,14 @@ public class ResponseServiceImpl extends ResponseCommonService implements Respon
         byte[] signatureBytes = Base64.getUrlDecoder().decode(serverPublicKeyCredential.getResponse().getSignature());
         boolean result = SignatureHelper.verifySignature(userKey.getPublicKey(), toBeSignedMessage, signatureBytes, userKey.getAlgorithm());
         if (!result) {
-            throw FIDO2ServerRuntimeException.makeSignatureVerificationError(userKey.getAaguid());
+            throw new FIDO2ServerRuntimeException(InternalErrorCode.ASSERTION_SIGNATURE_VERIFICATION_FAIL, "Signature verification failed", userKey.getAaguid());
         }
     }
 
-    protected VerifyCredentialResult createVerifyCredentialResult(AuthenticatorData authData, UserKey userKey, String aaguid) {
+    protected VerifyCredentialResult createVerifyCredentialResult(AuthenticatorData authData, UserKey userKey) {
         return VerifyCredentialResult
                 .builder()
-                .aaguid(aaguid)
+                .aaguid(userKey.getAaguid())
                 .userId(userKey.getId())
                 .userVerified(authData.isUserVerified())
                 .userPresent(authData.isUserPresent())

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ResponseServiceImpl.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ResponseServiceImpl.java
@@ -243,7 +243,7 @@ public class ResponseServiceImpl extends ResponseCommonService implements Respon
         if (!StringUtils.isEmpty(serverPublicKeyCredential.getResponse().getUserHandle())) {
             if (!userKey.getId().equals(serverPublicKeyCredential.getResponse().getUserHandle())) {
                 // MUST identical to uerHandle
-                throw new FIDO2ServerRuntimeException(InternalErrorCode.USER_HANDLE_NOT_MATCHED,"User handle is not matched",userKey.getAaguid());
+                throw new FIDO2ServerRuntimeException(InternalErrorCode.USER_HANDLE_NOT_MATCHED, "User handle is not matched", userKey.getAaguid());
             }
         }
     }

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ResponseServiceImpl.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ResponseServiceImpl.java
@@ -206,7 +206,7 @@ public class ResponseServiceImpl extends ResponseCommonService implements Respon
         checkSignCounter(authData, userKey);
         // return authentication processing result
         log.info("[Finish handling assertion]");
-        return createVerifyCredentialResult(authData, userKey);
+        return createVerifyCredentialResult(authData, userKey, userKey.getAaguid());
     }
 
     protected void checkCredentialId(ServerAuthPublicKeyCredential serverPublicKeyCredential, Session session) {
@@ -304,9 +304,10 @@ public class ResponseServiceImpl extends ResponseCommonService implements Respon
         }
     }
 
-    protected VerifyCredentialResult createVerifyCredentialResult(AuthenticatorData authData, UserKey userKey) {
+    protected VerifyCredentialResult createVerifyCredentialResult(AuthenticatorData authData, UserKey userKey, String aaguid) {
         return VerifyCredentialResult
                 .builder()
+                .aaguid(aaguid)
                 .userId(userKey.getId())
                 .userVerified(authData.isUserVerified())
                 .userPresent(authData.isUserPresent())

--- a/server/src/main/resources/static/docs/api-guide.html
+++ b/server/src/main/resources/static/docs/api-guide.html
@@ -631,7 +631,7 @@ Content-Length: 1471
     "id" : "65fUCTlqPlOSk22tkrkJ2m8I2MEhpF4fCI_pdosMAzk",
     "displayName" : "Test Display Name"
   },
-  "challenge" : "dmb5o1rULgh6shfkNb1NVes5FSUsnOU9hIhETnGcVJzysrw2TLzIQPPExrPSGTp5OWknko0fCCyASoZL0rqsig",
+  "challenge" : "XR2NGK0HZW1-gUeuaPoLpf48ZFjz0sN2e5QfWZN7aIgjeXPksmJmJ0F0Oq9DHGZ74EvzejyEW6PHADMLxdqeng",
   "pubKeyCredParams" : [ {
     "type" : "public-key",
     "alg" : -65535
@@ -677,7 +677,7 @@ Content-Length: 1471
     "userVerification" : "preferred"
   },
   "attestation" : "none",
-  "sessionId" : "0de6b968-ae0f-4bed-8446-ea35459fe89e",
+  "sessionId" : "6f5a8fbb-e801-4077-9b90-f5598a419604",
   "extensions" : {
     "credProps" : true
   }
@@ -794,7 +794,7 @@ Content-Length: 624
     "internalErrorCode" : 0,
     "internalErrorCodeDescription" : null
   },
-  "challenge" : "hrImlxUL6q0-VsDZmbPS8wM5h3mirkeyGr68MMVT_1vN-cgKYjqKUb4cRK0ArZZxrpTe0erApCu2jQOSeV4Jhw",
+  "challenge" : "nf15HXQ11EdR8ckcVJn-UDt59rHSnOF0JEgB53W65CZX2IL1pAf22XEIXnGnkCHssogQZ4VWHfDa3u7VSScEkw",
   "timeout" : 180000,
   "rpId" : "localhost",
   "allowCredentials" : [ {
@@ -802,7 +802,7 @@ Content-Length: 624
     "id" : "AUTjvBgL29DEg4aoRVchh4KSi9cLUmNuL4JqH4H8RTvKaBVDu88CnXGHDTkpIag5ODydvM-UP5FgqzDzzM3A_tzLSeoWc7hnkQK3g0N0jifjatDHgXX6YmMVAJc"
   } ],
   "userVerification" : "preferred",
-  "sessionId" : "0929a279-17f7-4f5f-806a-5f1d6d1436c8",
+  "sessionId" : "048fc496-7de8-41e7-acf7-6da60885f436",
   "extensions" : { }
 }</code></pre>
 </div>
@@ -856,7 +856,7 @@ Host: localhost:8080
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 269
+Content-Length: 322
 
 {
   "serverResponse" : {
@@ -865,6 +865,7 @@ Content-Length: 269
     "internalErrorCode" : 0,
     "internalErrorCodeDescription" : null
   },
+  "aaguid" : "adce0002-35bc-c60a-648b-0b25f1f05503",
   "userId" : "65fUCTlqPlOSk22tkrkJ2m8I2MEhpF4fCI_pdosMAzk",
   "userVerified" : true,
   "userPresent" : true
@@ -1234,7 +1235,7 @@ OK</code></pre>
 <div id="footer">
 <div id="footer-text">
 Version 0.1.1-SNAPSHOT<br>
-Last updated 2021-10-22 14:30:49 +0900
+Last updated 2021-11-06 19:24:20 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/server/src/test/resources/json/auth/auth-response-res.json
+++ b/server/src/test/resources/json/auth/auth-response-res.json
@@ -7,5 +7,6 @@
   },
   "userId": "65fUCTlqPlOSk22tkrkJ2m8I2MEhpF4fCI_pdosMAzk",
   "userVerified": true,
-  "userPresent": true
+  "userPresent": true,
+  "aaguid":"adce0002-35bc-c60a-648b-0b25f1f05503"
 }


### PR DESCRIPTION
# What is this PR for?

## Overview or reasons
Regarding #12 

## Tasks
- Add aaguid as a member of VerifyCredentialResult. (When authentication is success)
- Add aaguid as a member of ASSERTION_SIGNATURE_VERIFICATION_FAIL exception response.
- Update API Guide.

## Result 

### Success

```java
public class VerifyCredentialResult implements ServerAPIResult {
    private ServerResponse serverResponse;
    private String aaguid;
    private String userId;
    private boolean userVerified;
    private boolean userPresent;
}
```
### ASSERTION_SIGNATURE_VERIFICATION_FAIL Exception

`... "body":{"serverResponse":{"description":"AAGUId: adce0002-35bc-c60a-648b-0b25f1f05503","internalError":"ASSERTION_SIGNATURE_VERIFICATION_FAIL","internalErrorCode":56,"internalErrorCodeDescription":null}}`
