### PR TITLE
Use debug level logging to avoid performance impact (#23)

### DIFF
--- a/rpserver/src/main/java/com/linecorp/line/auth/fido/fido2/rpserver/controller/AdapterController.java
+++ b/rpserver/src/main/java/com/linecorp/line/auth/fido/fido2/rpserver/controller/AdapterController.java
@@ -78,8 +78,8 @@ public class AdapterController {
 
         fidoServerHost = fidoServerConfig.getHost();
         scheme = fidoServerConfig.getScheme();
-        log.info("fidoServerHost: " + fidoServerHost);
-        log.info("scheme: " + scheme);
+        log.debug("fidoServerHost: {}", fidoServerHost);
+        log.debug("scheme: {}", scheme);
 
         regChallengeUri = uriComponentsBuilder
                 .scheme(scheme)

--- a/rpserver/src/main/java/com/linecorp/line/auth/fido/fido2/rpserver/controller/CredentialController.java
+++ b/rpserver/src/main/java/com/linecorp/line/auth/fido/fido2/rpserver/controller/CredentialController.java
@@ -62,8 +62,8 @@ public class CredentialController {
         fidoServerHost = fidoServerConfig.getHost();
         scheme = fidoServerConfig.getScheme();
 
-        log.info("fidoServerHost: " + fidoServerHost);
-        log.info("scheme: " + scheme);
+        log.debug("fidoServerHost: {}", fidoServerHost);
+        log.debug("scheme: {}", scheme);
 
         getDeleteCredentialsUri = uriComponentsBuilder
                 .scheme(scheme)

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/attestation/apple/AppleAnonymousAttestationVerifier.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/attestation/apple/AppleAnonymousAttestationVerifier.java
@@ -58,7 +58,7 @@ public class AppleAnonymousAttestationVerifier implements AttestationVerifier {
     public AttestationVerificationResult verify(AttestationStatement attestationStatement, AuthenticatorData authenticatorData, byte[] clientDataHash) {
         AppleAnonymousAttestationStatement appleAnonymous = (AppleAnonymousAttestationStatement) attestationStatement;
 
-        log.info("Prepare nonceToHash");
+        log.debug("Prepare nonceToHash");
         byte[] expectedNonceToHash = ByteBuffer
                 .allocate(authenticatorData.getBytes().length + clientDataHash.length)
                 .put(authenticatorData.getBytes())

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/attestation/tpm/TpmAttestationVerifier.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/attestation/tpm/TpmAttestationVerifier.java
@@ -235,8 +235,7 @@ public class TpmAttestationVerifier implements AttestationVerifier {
         final String OID_TCG_AT_TPM_MODEL = "2.23.133.2.2";
         final String OID_TCG_AT_TPM_VERSION = "2.23.133.2.3";
 
-        log.info("AIK Cert Information");
-        log.info(aikCert.toString());
+        log.debug("AIK Cert Information: {}", aikCert);
 
         try {
             // check version (MUST be set to 3)
@@ -291,7 +290,7 @@ public class TpmAttestationVerifier implements AttestationVerifier {
             }
 
             TpmSubjectAlternativeName alternativeName = builder.build();
-            log.info("TPM Subject Alternative name: {}", alternativeName);
+            log.debug("TPM Subject Alternative name: {}", alternativeName);
 
             // check extended key usage extension (MUST contain tcg-kp-AIKCertificate oid)
             List<String> extendedKeyUsage = aikCert.getExtendedKeyUsage();
@@ -308,17 +307,17 @@ public class TpmAttestationVerifier implements AttestationVerifier {
             byte[] authInfoAccessExtensionValue = aikCert.getExtensionValue(
                     Extension.authorityInfoAccess.getId());
 
-            log.info("AIA extension info (Optional)");
+            log.debug("AIA extension info (Optional)");
             AccessDescription[] accessDescriptions = getAccessDescriptions(authInfoAccessExtensionValue);
             if (accessDescriptions != null) {
                 for (AccessDescription accessDescription : accessDescriptions) {
 
                     if (accessDescription.getAccessMethod().equals(OCSP_ACCESS_METHOD)) {
-                        log.info("AIA: OCSP enabled");
+                        log.debug("AIA: OCSP enabled");
                     }
 
                     if (accessDescription.getAccessMethod().equals(CRL_ACCESS_METHOD)) {
-                        log.info("AIA: CRL enabled");
+                        log.debug("AIA: CRL enabled");
                     }
 
                     GeneralName gn = accessDescription.getAccessLocation();
@@ -327,7 +326,7 @@ public class TpmAttestationVerifier implements AttestationVerifier {
                     }
 
                     DERIA5String str = (DERIA5String) ((DERTaggedObject) gn.toASN1Primitive()).getObject();
-                    log.info("Access Location: {}", str.getString());
+                    log.debug("Access Location: {}", str);
                 }
             }
 

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/helper/ExtensionHelper.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/helper/ExtensionHelper.java
@@ -24,24 +24,20 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ExtensionHelper {
     public static UserKey createUserKeyWithExtensions(UserKey.UserKeyBuilder userKeyBuilder, AuthenticationExtensionsClientOutputs clientExtensions, AuthenticatorExtension authenticatorExtensions) {
-        // verify extension
-        log.info("Verify extension");
-
-        // check authenticator extensions
-        log.info("Check authenticator extension");
+        log.debug("Check authenticator extension");
 
         if (authenticatorExtensions != null) {
             log.debug("Extensions: {}", authenticatorExtensions);
             if (authenticatorExtensions.getCredProtect() != null) {
-                log.info("Handle credProtect extension");
+                log.debug("Handle credProtect extension");
                 userKeyBuilder.credProtect(authenticatorExtensions.getCredProtect().getValue());
             }
         }
 
         // check client extensions
-        log.info("Check client extension");
+        log.debug("Check client extension");
         if (clientExtensions != null) {
-            log.info("Client extension output: {}", clientExtensions);
+            log.debug("Client extension output: {}", clientExtensions);
             if (clientExtensions.getCredProps() != null) {
                 userKeyBuilder.rk(clientExtensions.getCredProps().getRk());
             }

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/model/AuthenticatorData.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/model/AuthenticatorData.java
@@ -122,7 +122,7 @@ public class AuthenticatorData {
     }
 
     protected static AuthenticatorExtension decodeAuthenticatorDataExtension(ByteArrayInputStream inputStream) throws IOException {
-        log.info("Extension is included");
+        log.debug("Extension is included");
         int extensionDataLength = inputStream.available();
         if (extensionDataLength > 0) {
             byte[] extensionsBytes = new byte[extensionDataLength];

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ChallengeServiceImpl.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ChallengeServiceImpl.java
@@ -142,8 +142,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         // write session
         sessionService.createSession(session);
 
-        log.debug("regOptionResponse: ");
-        log.debug(regOptionResponse.toString());
+        log.debug("regOptionResponse: {}", regOptionResponse);
 
         return regOptionResponse;
     }
@@ -214,8 +213,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         // write session
         sessionService.createSession(session);
 
-        log.debug("authOptionResponse:");
-        log.debug(authOptionResponse.toString());
+        log.debug("authOptionResponse: {}", authOptionResponse);
 
         return authOptionResponse;
     }

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ResponseCommonService.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ResponseCommonService.java
@@ -52,7 +52,7 @@ abstract public class ResponseCommonService {
      */
     public byte[] handleCommon(String type, String challengeSent, String base64UrlEncodedClientDataJSON, String origin, TokenBinding tokenBinding) {
         String clientDataJSON = new String(Base64.getUrlDecoder().decode(base64UrlEncodedClientDataJSON));
-        log.info("clientDataJSON: {}", clientDataJSON);
+        log.debug("clientDataJSON: {}", clientDataJSON);
         CollectedClientData collectedClientData;
         try {
             collectedClientData = getCollectedClientData(clientDataJSON);
@@ -61,7 +61,7 @@ abstract public class ResponseCommonService {
         }
         byte[] clientDataJSONBytes = clientDataJSON.getBytes();
 
-        log.info("collectedClientData: {}", collectedClientData);
+        log.debug("collectedClientData: {}", collectedClientData);
         // verify collected client data
         if (StringUtils.isEmpty(collectedClientData.getType()) ||
                 StringUtils.isEmpty(collectedClientData.getChallenge()) ||
@@ -70,19 +70,19 @@ abstract public class ResponseCommonService {
         }
 
         // verify challenge (should be matched to challenge sent in create call)
-        log.info("Verify challenge matched to challenge sent");
+        log.debug("Verify challenge matched to challenge sent");
         if (!collectedClientData.getChallenge().equals(challengeSent)) {
             throw new FIDO2ServerRuntimeException(InternalErrorCode.CHALLENGE_NOT_MATCHED);
         }
 
         // verify type
-        log.info("Check operation type in collectedClientData");
+        log.debug("Check operation type in collectedClientData");
         if (!type.equals(collectedClientData.getType())) {
             throw new FIDO2ServerRuntimeException(InternalErrorCode.INVALID_OPERATION_TYPE);
         }
 
         // verify origin
-        log.info("Verify origin matched to origin in collectedClientData");
+        log.debug("Verify origin matched to origin in collectedClientData");
         URI originFromClientData;
         URI originFromRp;
         try {
@@ -95,7 +95,7 @@ abstract public class ResponseCommonService {
         checkOrigin(originFromClientData, originFromRp);
 
         // verify token binding
-        log.info("Verify token binding if supported");
+        log.debug("Verify token binding if supported");
         if (collectedClientData.getTokenBinding() != null) {
             if (collectedClientData.getTokenBinding().getStatus() == null) {
                 throw new FIDO2ServerRuntimeException(InternalErrorCode.TOKEN_BINDING_STATUS_MISSING);
@@ -117,7 +117,7 @@ abstract public class ResponseCommonService {
         }
 
         // compute hash of clientDataJSON
-        log.info("Compute hash of clientDataJSON");
+        log.debug("Compute hash of clientDataJSON");
 
         return Digests.sha256(clientDataJSONBytes);
     }


### PR DESCRIPTION
# What is this PR for?

Resolves #23 by logging debug logs at an appropriate logging level to make server less busy for logging during high traffic rate.

## Overview or reasons
It appears that current logs in the FIDO server are mainly for debugging purpose, but they are logged in info level.

As a result, even if info level is configured in logback, they are always logged. When traffic rate is high, the server becomes busy for logging.

On the other hand, some logs passes parameters with manual string construction instead of {} placeholder, so the impact is even larger. (See https://www.slf4j.org/faq.html#logging_performance for details)

## Tasks
- Align all debugging logs to be `debug` level: `log.info` -> `log.debug`
- Use `{}` placeholders in log message whenever possible
- Pass objects directly as message parameters instead of manual string construction like `toString` or `String.format`. This can avoid redundant computation when the log is not required for the configured log level.
- Prepare Base64url encoded strings for logging and share it in multiple debug logs to avoid redundant encoding.
  - Note that the encoding is still performed no matter what log level is. Since changing log level should have significant improvement, this PR keeps this change minimal.

## Result
- The logs are only logged when logback is configured to `debug` level.