### PR TITLE
Rename `TxAuthGenericAlg` to `TxAuthGenericArg`

### DIFF
--- a/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/extension/AuthenticationExtensionsClientInputs.java
+++ b/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/extension/AuthenticationExtensionsClientInputs.java
@@ -30,7 +30,7 @@ import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 public class AuthenticationExtensionsClientInputs {
     private String appid;
     private String txAuthSimple;
-    private TxAuthGenericAlg txAuthGeneric;
+    private TxAuthGenericArg txAuthGeneric;
     private List<String> authnSel;
     private List<String> line_authnSel;
     private Boolean exts;

--- a/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/extension/TxAuthGenericArg.java
+++ b/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/extension/TxAuthGenericArg.java
@@ -19,7 +19,7 @@ package com.linecorp.line.auth.fido.fido2.common.extension;
 import lombok.Data;
 
 @Data
-public class TxAuthGenericAlg {
+public class TxAuthGenericArg {
     private String contentType;
     private String content;
 }


### PR DESCRIPTION
# What is this PR for?

Rename to `TxAuthGenericArg` from `TxAuthGenericAlg`.

## Overview or reasons

Looking at the spec, [Web Authentication: An API for accessing Public Key Credentials Level 1 -> 10.3. Generic Transaction Authorization Extension (txAuthGeneric)](https://www.w3.org/TR/webauthn-1/#sctn-generic-txauth-extension), I think `TxAuthGenericAlg` is simply typo.

## Tasks

Renamed with IntelliJ's refactoring feature.

## Result

Successfully renamed
