### PR TITLE
Fix COSE algorithm value for ES256K

### DIFF
--- a/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/COSEAlgorithmIdentifier.java
+++ b/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/COSEAlgorithmIdentifier.java
@@ -37,7 +37,7 @@ public enum COSEAlgorithmIdentifier {
     ES384(-35),
     ES512(-36),
     EdDSA(-8),
-    ES256K(-43);
+    ES256K(-47);
 
     @JsonValue
     @Getter private final long value;

--- a/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/server/COSEAlgorithm.java
+++ b/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/server/COSEAlgorithm.java
@@ -35,7 +35,7 @@ public enum COSEAlgorithm {
     ES256("ES256", -7, "ECDSA w/ SHA-256", true),
     ES384("ES384", -35, "ECDSA w/ SHA-384", true),
     ES512("ES512", -36, "ECDSA w/ SHA-512", true),
-    ES256K("ES256K", -43, "ECDSA using P-256K and SHA-256", false);
+    ES256K("ES256K", -47, "ECDSA using P-256K and SHA-256", false);
 
     private final String name;
     private final int value;

--- a/server/src/test/resources/json/reg/reg-challenge-res.json
+++ b/server/src/test/resources/json/reg/reg-challenge-res.json
@@ -64,7 +64,7 @@
     },
     {
       "type": "public-key",
-      "alg": -43
+      "alg": -47
     }
   ],
   "timeout": 180000,


### PR DESCRIPTION
# What is this PR for?

This PR will fix invalid COSE algorithm value.

## Overview or reasons

Accoding to [IANA CBOR Object Signing and Encryption (COSE) Algorithms Registry](https://www.iana.org/assignments/cose/cose.xhtml#algorithms), the value of *ES256K* is `-47`. But the code defines it as `-43`.


## Tasks

I changed the value in production code and test code, and ran tests.

## Result

Tests were success.