### PR TITLE
Fix: Correct API endpoint mismatch in CredentialController

### DIFF
--- a/rpserver/src/main/java/com/linecorp/line/auth/fido/fido2/rpserver/controller/CredentialController.java
+++ b/rpserver/src/main/java/com/linecorp/line/auth/fido/fido2/rpserver/controller/CredentialController.java
@@ -81,7 +81,7 @@ public class CredentialController {
             @PathVariable("id") String credentialId) {
 
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(getDeleteCredentialsUri);
-        URI uri = uriComponentsBuilder.path(credentialId)
+        URI uri = uriComponentsBuilder.pathSegment(credentialId)
                                       .queryParam("rpId", rpId)
                                       .build().toUri();
 
@@ -112,7 +112,7 @@ public class CredentialController {
             @PathVariable("id") String credentialId) {
 
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder.fromUriString(getDeleteCredentialsUri);
-        URI uri = uriComponentsBuilder.path(credentialId)
+        URI uri = uriComponentsBuilder.pathSegment(credentialId)
                                       .queryParam("rpId", rpId)
                                       .build().toUri();
 


### PR DESCRIPTION
# What is this PR for?
Fixing API Endpoint Mismatch Issue in CredentialController

## Overview or reasons
I have identified an issue in the CredentialController on the server.
Currently, the endpoint for receiving requests is set as /fido2/credentials/{id}, but I noticed that when constructing the API address on the rpserver, it is being called as /fido2/credentials{id}. 
As a result, the credentials API cannot be successfully invoked.

## Tasks
When calling the credentials API, you need to configure the address of that API in rpserver, pathSegment function when calling the credentials API.

## Result
Now able to call the server's credential/{id} api from rpserver as normal.