### PR TITLE
FIX Timeout for ANDROID_SAFETYNET_ATTESTATION

### DIFF
--- a/fido2-core/src/main/java/com/linecorp/line/auth/fido/fido2/server/attestation/android/safetynet/AndroidSafetyNetAttestationVerifier.java
+++ b/fido2-core/src/main/java/com/linecorp/line/auth/fido/fido2/server/attestation/android/safetynet/AndroidSafetyNetAttestationVerifier.java
@@ -178,7 +178,7 @@ public class AndroidSafetyNetAttestationVerifier implements AttestationVerifier 
                 if (attestationStatementInfo.getTimestampMs() >= currentTime) {
                     throw new FIDO2ServerRuntimeException(InternalErrorCode.ANDROID_SAFETYNET_ATTESTATION_TIMESTAMP_INVALID);
                 }
-                if ((currentTime - attestationStatementInfo.getTimestampMs()) > 60 * 100) {
+                if ((currentTime - attestationStatementInfo.getTimestampMs()) > 60 * 1000) {
                     throw new FIDO2ServerRuntimeException(InternalErrorCode.ANDROID_SAFETYNET_ATTESTATION_TIMESTAMP_INVALID);
                 }
 


### PR DESCRIPTION
# What is this PR for?
This pull request is intended to fix a critical issue in the timestamp validation logic used in the SafetyNet attestation process for Android devices. The adjustment ensures the validity period check is accurate and compliant with security standards.

## Overview or reasons
The existing code used to validate the timestamp in SafetyNet attestation had an error in the multiplication factor, resulting in a shorter threshold than intended. Specifically, the condition mistakenly used 60 * 100 milliseconds (6 seconds), whereas it should be 60 * 1000 milliseconds (60 seconds or 1 minute). This discrepancy could lead to premature rejection of valid attestations.

## Tasks
Code Correction: Modified the multiplier in the timestamp validation from 100 to 1000, correcting the threshold from 6000 milliseconds to 60000 milliseconds.

## Result
The correction to the timestamp validation logic now ensures that the threshold is set correctly at 60000 milliseconds (1 minute). This fix aligns the implementation with the intended security specifications and prevents the erroneous rejection of valid SafetyNet attestations.