### PR TITLE
Make the embedded Redis can run on Apple silicon

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:8-jdk
 WORKDIR /workspace/app
 COPY . .
 RUN ./rpserver/gradlew bootJar

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM eclipse-temurin:8-jdk
 WORKDIR /workspace/app
 COPY . .
-RUN ./rpserver/gradlew bootJar
-RUN ./server/gradlew dockerBuild
+RUN --mount=type=cache,target=/root/.gradle \
+	./rpserver/gradlew --no-daemon bootJar
+RUN --mount=type=cache,target=/root/.gradle \
+	./server/gradlew --no-daemon dockerBuild

--- a/README.md
+++ b/README.md
@@ -107,8 +107,12 @@ cd spring-boot-starter/line-fido2-spring-boot-demo
 If the [Docker environment is configured](https://docs.docker.com/get-started/), You can easily run applications with docker-compose.
 
 ```bash
+# Build docker images
+docker build -t build-image .
+docker compose build
+
 # Start both RP Server and FIDO2 Server
-docker-compose up
+docker compose up
 ```
 
 After running the applications, you can open the test page at the link below.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version : "3.8"
 services:
     build:
       container_name: build-image

--- a/rpserver/Dockerfile
+++ b/rpserver/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-alpine
+FROM eclipse-temurin:8-jre
 EXPOSE 8080
 COPY --from=build-image:latest /workspace/app/rpserver/build/libs/rpserver-*.jar rpserver.jar
-ENTRYPOINT ["java","-jar","-Dspring.profiles.active=docker","/rpserver.jar"]
+CMD ["java","-Dspring.profiles.active=docker","-jar","/rpserver.jar"]

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:8-jdk-slim
+FROM eclipse-temurin:8-jre
 EXPOSE 8081
 COPY --from=build-image:latest /workspace/app/server/build/libs/server-*.jar server.jar
-ENTRYPOINT ["java","-jar","/server.jar"]
+CMD ["java","-jar","/server.jar"]

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -107,7 +107,7 @@ dependencies {
     implementation('com.auth0:java-jwt:3.4.0')
 
     //local redis
-    implementation('com.github.kstyrc:embedded-redis:0.6')
+    implementation('com.github.codemonstur:embedded-redis:1.4.3')
 
     //bouncy castle
     implementation('org.bouncycastle:bcprov-jdk15on:1.60')

--- a/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/config/EmbeddedRedisServerConfig.java
+++ b/server/src/main/java/com/linecorp/line/auth/fido/fido2/server/config/EmbeddedRedisServerConfig.java
@@ -46,7 +46,7 @@ public class EmbeddedRedisServerConfig {
     }
 
     @PreDestroy
-    public void stopRedis() {
+    public void stopRedis() throws IOException {
         redisServer.stop();
     }
 


### PR DESCRIPTION
# What is this PR for?

- Make the embedded Redis can run on Apple silicon
- See #45

## Overview or reasons

- Unable to run fido2 server on Apple silicon: `Error creating bean with name 'embeddedRedisServerConfig': Invocation of init method failed; nested exception is java.lang.RuntimeException: Can't start redis server. Check logs for details.`

## Tasks

- Replace the https://github.com/kstyrc/embedded-redis by https://github.com/codemonstur/embedded-redis
- Add instruction to build docker images
- Remove obsoleted top-level version property in `docker-compose.yml`
- Migrate base image from [openjdk](https://hub.docker.com/_/openjdk) to [eclipse-temurin](https://hub.docker.com/_/eclipse-temurin)
- Improve the Gradle building performance

## Result

- Run fido2 server on Apple silicon without errors