### PR TITLE
Add a substitute function for execution on Windows OS

### DIFF
--- a/fido2-demo/demo/src/main/java/com/linecorp/line/auth/fido/fido2/demo/config/EmbeddedRedisServerConfiguration.java
+++ b/fido2-demo/demo/src/main/java/com/linecorp/line/auth/fido/fido2/demo/config/EmbeddedRedisServerConfiguration.java
@@ -68,6 +68,17 @@ public class EmbeddedRedisServerConfiguration {
         String command = String.format("netstat -nat | grep LISTEN|grep %d", port);
         String[] shell = {"/bin/sh", "-c", command};
         return Runtime.getRuntime().exec(shell);
+
+    }
+
+    /**
+     * @brief The executeGrepProcessWindowCommand function can be used as a replacement for the executeGrepProcessCommand function when running on Windows OS.
+     */
+    private Process executeGrepProcessWindowCommand(int port) throws IOException {
+        String command = String.format("netstat -an | findstr :%d", port);
+        String[] shell = {"cmd.exe", "/c", command};  // cmd.exe에서 명령어 실행
+        return Runtime.getRuntime().exec(shell);
+
     }
 
     private boolean isRunning(Process process) {


### PR DESCRIPTION
# What is this PR for?
The executeGrepProcessWindowCommand function can be used as a replacement for the executeGrepProcessCommand function when running on Windows OS.

## Overview or reasons
- Please explain the contents.
Add a function for testing the server on Windows OS.

## Tasks
- Please explain what did you do.
Add executeGrepProcessWindowCommand function to EmbeddedRedisServerConfiguration class.

## Result
- Please Describe the result
Verify proper functionality on Windows OS with executeGrepProcessWindowCommand function.

The original error was as follows: Cannot run program "/bin/sh": CreateProcess error=2
![window_error](https://github.com/user-attachments/assets/83a71ac3-d795-4471-bf1d-3734bc2c5982)

After taking action, it now appears as follows:Completed
![window_success](https://github.com/user-attachments/assets/35e04939-8744-4c4a-a0da-aaaa885ce3c5)

The code in the EmbeddedRedisServerConfiguration class needs to be modified when running on Windows OS.


```    
private boolean isRedisRunning() throws IOException {
        return isRunning(executeGrepProcessWindowCommand(redisPort));
    }
```

```    
public int findAvailablePort() throws IOException {

        for (int port = 10000; port <= 65535; port++) {
            Process process = executeGrepProcessWindowCommand(port);
            if (!isRunning(process)) {
                return port;
            }
        }

        throw new IllegalArgumentException("Not Found Available port: 10000 ~ 65535");
    }
```