### PR TITLE
Add maven publish task for common and fido2-core modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,20 @@ subprojects {
     group = 'com.linecorp.line.auth.fido.fido2'
     version = '1.0.0-SNAPSHOT'
 
+    ext {
+        getMavenPublishUrl = {
+            return findProperty("publish.maven.url")
+        }
+
+        getMavenPublishUsername = {
+            return findProperty("publish.maven.username")
+        }
+
+        getMavenPublishPassword = {
+            return findProperty("publish.maven.password")
+        }
+    }
+
     repositories {
         mavenCentral()
         maven {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -18,6 +18,29 @@ test {
     useJUnitPlatform()
 }
 
+publishing {
+    publications {
+        mavenJar(MavenPublication) {
+            from components.java
+        }
+    }
+
+    repositories {
+        maven {
+            url = project.ext.getMavenPublishUrl()
+
+            if (project.ext.getMavenPublishUsername() != null) {
+                credentials {
+                    username = project.ext.getMavenPublishUsername()
+                    if (project.ext.getMavenPublishPassword() != null) {
+                        password = project.ext.getMavenPublishPassword()
+                    }
+                }
+            }
+        }
+    }
+}
+
 dependencies {
     compile('com.fasterxml.jackson.core:jackson-databind:2.9.6')
     compile('com.fasterxml.jackson.core:jackson-core:2.9.6')

--- a/fido2-core/build.gradle
+++ b/fido2-core/build.gradle
@@ -22,6 +22,29 @@ plugins {
 jar.enabled = true
 bootJar.enabled = false
 
+publishing {
+    publications {
+        mavenJar(MavenPublication) {
+            from components.java
+        }
+    }
+
+    repositories {
+        maven {
+            url = project.ext.getMavenPublishUrl()
+
+            if (project.ext.getMavenPublishUsername() != null) {
+                credentials {
+                    username = project.ext.getMavenPublishUsername()
+                    if (project.ext.getMavenPublishPassword() != null) {
+                        password = project.ext.getMavenPublishPassword()
+                    }
+                }
+            }
+        }
+    }
+}
+
 dependencies {
     implementation project(':common')
 


### PR DESCRIPTION
# What is this PR for?
Publish common and fido2-core modules into user-defined maven repository.

## Overview or reasons
- Ease to publish core modules into maven repository and use it.

## Tasks
- Add gradle script for maven publication.
- Define `publish.maven.url`, `publish.maven.username`, `publish.maven.password` properties.

## Result
- Publish artifacts by running command below:

```
./gradlew publish \
-Ppublish.maven.url={Repo URL} \
-Ppublish.maven.username={username} \
-Ppublish.maven.password={password}
```

Artifacts will be published as `com.linecorp.line.auth.fido.fido2:{common,fido2-core}`
