### PR TITLE
Support PRF extension

### DIFF
--- a/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/Extension.java
+++ b/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/Extension.java
@@ -33,7 +33,8 @@ public enum Extension {
     SUPPORTED_EXTENSIONS("exts"),
     USER_VERIFICATION_INDEX("uvi"),
     LOCATION("loc"),
-    BIOMETRIC_AUTHENTICATOR_PERFORMANCE_BOUNDS("biometricPerfBounds");
+    BIOMETRIC_AUTHENTICATOR_PERFORMANCE_BOUNDS("biometricPerfBounds"),
+    PSEUDO_RANDOM_FUNCTION("prf");
 
     @JsonValue
     @Getter

--- a/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/extension/AuthenticationExtensionsClientInputs.java
+++ b/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/extension/AuthenticationExtensionsClientInputs.java
@@ -42,4 +42,5 @@ public class AuthenticationExtensionsClientInputs {
     // Credential Protection (credProtect)
     private CredentialProtectionPolicy credentialProtectionPolicy;
     private Boolean enforceCredentialProtectionPolicy;  // if true, it should fail
+    private PRFInputs prf;
 }

--- a/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/extension/AuthenticationExtensionsClientOutputs.java
+++ b/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/extension/AuthenticationExtensionsClientOutputs.java
@@ -31,4 +31,5 @@ public class AuthenticationExtensionsClientOutputs {
     private Coordinates loc;
     private Boolean biometricPerfBounds;
     private CredentialPropertiesOutput credProps;
+    private PRFOutputs prf;
 }

--- a/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/extension/PRFInputs.java
+++ b/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/extension/PRFInputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 LY Corporation
+ * Copyright 2025 LY Corporation
  *
  * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -14,27 +14,15 @@
  * under the License.
  */
 
-package com.linecorp.line.auth.fido.fido2.common.server;
+package com.linecorp.line.auth.fido.fido2.common.extension;
 
+import java.util.Map;
 
-import javax.validation.constraints.NotBlank;
-
-import com.linecorp.line.auth.fido.fido2.common.UserVerificationRequirement;
-import com.linecorp.line.auth.fido.fido2.common.extension.PRFInputs;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 @Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class AuthOptionRequest {
-    @NotBlank
-    private String rpId;
-    private String userId;
-    private UserVerificationRequirement userVerification;
-    private PRFInputs prf;
+public class PRFInputs {
+    private PRFValues eval;
+    // A record mapping base64url encoded credential IDs to PRF inputs
+    private Map<String, PRFValues> evalByCredential;
 }

--- a/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/extension/PRFOutputs.java
+++ b/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/extension/PRFOutputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 LY Corporation
+ * Copyright 2025 LY Corporation
  *
  * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -14,27 +14,12 @@
  * under the License.
  */
 
-package com.linecorp.line.auth.fido.fido2.common.server;
+package com.linecorp.line.auth.fido.fido2.common.extension;
 
-
-import javax.validation.constraints.NotBlank;
-
-import com.linecorp.line.auth.fido.fido2.common.UserVerificationRequirement;
-import com.linecorp.line.auth.fido.fido2.common.extension.PRFInputs;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 @Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class AuthOptionRequest {
-    @NotBlank
-    private String rpId;
-    private String userId;
-    private UserVerificationRequirement userVerification;
-    private PRFInputs prf;
+public class PRFOutputs {
+    private Boolean enabled;
+    private PRFValues results;
 }

--- a/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/extension/PRFValues.java
+++ b/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/extension/PRFValues.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 LY Corporation
+ * Copyright 2025 LY Corporation
  *
  * LY Corporation licenses this file to you under the Apache License,
  * version 2.0 (the "License"); you may not use this file except in compliance
@@ -14,27 +14,15 @@
  * under the License.
  */
 
-package com.linecorp.line.auth.fido.fido2.common.server;
+package com.linecorp.line.auth.fido.fido2.common.extension;
 
+import javax.validation.constraints.NotNull;
 
-import javax.validation.constraints.NotBlank;
-
-import com.linecorp.line.auth.fido.fido2.common.UserVerificationRequirement;
-import com.linecorp.line.auth.fido.fido2.common.extension.PRFInputs;
-
-import lombok.AllArgsConstructor;
-import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
 
 @Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
-public class AuthOptionRequest {
-    @NotBlank
-    private String rpId;
-    private String userId;
-    private UserVerificationRequirement userVerification;
-    private PRFInputs prf;
+public class PRFValues {
+    @NotNull
+    private String first; // Base64url encoded string
+    private String second; // Base64url encoded string
 }

--- a/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/server/RegOptionRequest.java
+++ b/common/src/main/java/com/linecorp/line/auth/fido/fido2/common/server/RegOptionRequest.java
@@ -23,6 +23,7 @@ import com.linecorp.line.auth.fido.fido2.common.AttestationConveyancePreference;
 import com.linecorp.line.auth.fido.fido2.common.AuthenticatorSelectionCriteria;
 import com.linecorp.line.auth.fido.fido2.common.PublicKeyCredentialRpEntity;
 import com.linecorp.line.auth.fido.fido2.common.extension.CredProtect;
+import com.linecorp.line.auth.fido.fido2.common.extension.PRFInputs;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -42,4 +43,5 @@ public class RegOptionRequest {
     private AuthenticatorSelectionCriteria authenticatorSelection;
     private AttestationConveyancePreference attestation;
     private CredProtect credProtect;
+    private PRFInputs prf;
 }

--- a/fido2-core/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ChallengeServiceImpl.java
+++ b/fido2-core/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ChallengeServiceImpl.java
@@ -126,6 +126,10 @@ public class ChallengeServiceImpl implements ChallengeService {
                     .setEnforceCredentialProtectionPolicy(regOptionRequest.getCredProtect().getEnforceCredentialProtectionPolicy());
         }
 
+        if (regOptionRequest.getPrf() != null) {
+            extensions.setPrf(regOptionRequest.getPrf());
+        }
+
         builder.extensions(extensions);
 
         // set server response
@@ -193,6 +197,11 @@ public class ChallengeServiceImpl implements ChallengeService {
 
         // set extension
         AuthenticationExtensionsClientInputs extensions = new AuthenticationExtensionsClientInputs();
+
+        if (authOptionRequest.getPrf() != null) {
+            extensions.setPrf(authOptionRequest.getPrf());
+        }
+
         builder.extensions(extensions);
 
         // create and set session

--- a/rpserver/src/main/java/com/linecorp/line/auth/fido/fido2/rpserver/controller/AdapterController.java
+++ b/rpserver/src/main/java/com/linecorp/line/auth/fido/fido2/rpserver/controller/AdapterController.java
@@ -64,7 +64,7 @@ public class AdapterController {
     private final RestTemplate restTemplate;
     private final FidoServerConfig fidoServerConfig;
 
-    private final String COOKIE_NAME = "fido2-session-id";
+    private static final String COOKIE_NAME = "fido2-session-id";
 
     @Autowired
     public AdapterController(RestTemplate restTemplate, FidoServerConfig fidoServerConfig) {
@@ -122,31 +122,32 @@ public class AdapterController {
             HttpServletResponse httpServletResponse) {
 
         // set header
-        HttpHeaders httpHeaders = new HttpHeaders();
+        final HttpHeaders httpHeaders = new HttpHeaders();
 
         // set options
-        PublicKeyCredentialRpEntity rp = new PublicKeyCredentialRpEntity();
+        final PublicKeyCredentialRpEntity rp = new PublicKeyCredentialRpEntity();
         rp.setName("Test RP");
         // just for test
         rp.setId(rpId);
-        ServerPublicKeyCredentialUserEntity user = new ServerPublicKeyCredentialUserEntity();
+        final ServerPublicKeyCredentialUserEntity user = new ServerPublicKeyCredentialUserEntity();
         user.setName(optionsRequest.getUsername());
         user.setId(createUserId(optionsRequest.getUsername()));
         user.setDisplayName(optionsRequest.getDisplayName());
 
-        RegOptionRequest regOptionRequest = RegOptionRequest
+        final RegOptionRequest regOptionRequest = RegOptionRequest
                 .builder()
                 .rp(rp)
                 .user(user)
                 .authenticatorSelection(optionsRequest.getAuthenticatorSelection())
                 .attestation(optionsRequest.getAttestation())
                 .credProtect(optionsRequest.getCredProtect())
+                .prf(optionsRequest.getPrf())
                 .build();
 
-        HttpEntity<RegOptionRequest> request = new HttpEntity<>(regOptionRequest, httpHeaders);
-        RegOptionResponse response = restTemplate.postForObject(regChallengeUri, request, RegOptionResponse.class);
+        final HttpEntity<RegOptionRequest> request = new HttpEntity<>(regOptionRequest, httpHeaders);
+        final RegOptionResponse response = restTemplate.postForObject(regChallengeUri, request, RegOptionResponse.class);
 
-        ServerPublicKeyCredentialCreationOptionsResponse serverResponse = ServerPublicKeyCredentialCreationOptionsResponse
+        final ServerPublicKeyCredentialCreationOptionsResponse serverResponse = ServerPublicKeyCredentialCreationOptionsResponse
                 .builder()
                 .rp(response.getRp())
                 .user(response.getUser())
@@ -172,10 +173,10 @@ public class AdapterController {
             @RequestBody AdapterRegServerPublicKeyCredential clientResponse,
             HttpServletRequest httpServletRequest) {
 
-        AdapterServerResponse serverResponse;
+        final AdapterServerResponse serverResponse;
 
         // get session id
-        Cookie[] cookies = httpServletRequest.getCookies();
+        final Cookie[] cookies = httpServletRequest.getCookies();
         if (cookies == null || cookies.length == 0) {
             //error
             serverResponse = new AdapterServerResponse();
@@ -193,9 +194,9 @@ public class AdapterController {
         }
 
         // prepare origin
-        String scheme = httpServletRequest.getScheme();
+        final String scheme = httpServletRequest.getScheme();
 
-        StringBuilder builder = new StringBuilder()
+        final StringBuilder builder = new StringBuilder()
                 .append(scheme)
                 .append("://")
                 .append(rpOrigin);
@@ -206,10 +207,10 @@ public class AdapterController {
         }
 
         // set header
-        HttpHeaders httpHeaders = new HttpHeaders();
+        final HttpHeaders httpHeaders = new HttpHeaders();
 
-        RegisterCredential registerCredential = new RegisterCredential();
-        ServerRegPublicKeyCredential serverRegPublicKeyCredential = new ServerRegPublicKeyCredential();
+        final RegisterCredential registerCredential = new RegisterCredential();
+        final ServerRegPublicKeyCredential serverRegPublicKeyCredential = new ServerRegPublicKeyCredential();
         serverRegPublicKeyCredential.setId(clientResponse.getId());
         serverRegPublicKeyCredential.setType(clientResponse.getType());
         serverRegPublicKeyCredential.setResponse(clientResponse.getResponse());
@@ -219,7 +220,7 @@ public class AdapterController {
         registerCredential.setSessionId(sessionId);
         registerCredential.setOrigin(builder.toString());
 
-        HttpEntity<RegisterCredential> request = new HttpEntity<>(registerCredential, httpHeaders);
+        final HttpEntity<RegisterCredential> request = new HttpEntity<>(registerCredential, httpHeaders);
 
         restTemplate.postForObject(regResponseUri, request, RegisterCredentialResult.class);
 
@@ -236,19 +237,20 @@ public class AdapterController {
             HttpServletResponse httpServletResponse) {
 
         // set header
-        HttpHeaders httpHeaders = new HttpHeaders();
+        final HttpHeaders httpHeaders = new HttpHeaders();
 
-        AuthOptionRequest authOptionRequest = AuthOptionRequest
+        final AuthOptionRequest authOptionRequest = AuthOptionRequest
                 .builder()
                 .rpId(rpId)
                 .userId(createUserId(optionRequest.getUsername()))
                 .userVerification(optionRequest.getUserVerification())
+                .prf(optionRequest.getPrf())
                 .build();
 
-        HttpEntity<AuthOptionRequest> request = new HttpEntity<>(authOptionRequest, httpHeaders);
-        AuthOptionResponse response = restTemplate.postForObject(authChallengeUri, request, AuthOptionResponse.class);
+        final HttpEntity<AuthOptionRequest> request = new HttpEntity<>(authOptionRequest, httpHeaders);
+        final AuthOptionResponse response = restTemplate.postForObject(authChallengeUri, request, AuthOptionResponse.class);
 
-        ServerPublicKeyCredentialGetOptionsResponse serverResponse;
+        final ServerPublicKeyCredentialGetOptionsResponse serverResponse;
         serverResponse = ServerPublicKeyCredentialGetOptionsResponse
                 .builder()
                 .allowCredentials(response.getAllowCredentials())
@@ -279,10 +281,10 @@ public class AdapterController {
             @RequestBody AdapterAuthServerPublicKeyCredential clientResponse,
             HttpServletRequest httpServletRequest) {
 
-        AdapterServerResponse serverResponse;
+        final AdapterServerResponse serverResponse;
 
         // get session id
-        Cookie[] cookies = httpServletRequest.getCookies();
+        final Cookie[] cookies = httpServletRequest.getCookies();
         if (cookies == null || cookies.length == 0) {
             //error
             serverResponse = new AdapterServerResponse();
@@ -300,8 +302,8 @@ public class AdapterController {
         }
 
         // prepare origin
-        String scheme = httpServletRequest.getScheme();
-        StringBuilder builder = new StringBuilder()
+        final String scheme = httpServletRequest.getScheme();
+        final StringBuilder builder = new StringBuilder()
                 .append(scheme)
                 .append("://")
                 .append(rpOrigin);
@@ -312,10 +314,10 @@ public class AdapterController {
         }
 
         // set header
-        HttpHeaders httpHeaders = new HttpHeaders();
+        final HttpHeaders httpHeaders = new HttpHeaders();
 
-        VerifyCredential verifyCredential = new VerifyCredential();
-        ServerAuthPublicKeyCredential serverAuthPublicKeyCredential = new ServerAuthPublicKeyCredential();
+        final VerifyCredential verifyCredential = new VerifyCredential();
+        final ServerAuthPublicKeyCredential serverAuthPublicKeyCredential = new ServerAuthPublicKeyCredential();
         serverAuthPublicKeyCredential.setResponse(clientResponse.getResponse());
         serverAuthPublicKeyCredential.setId(clientResponse.getId());
         serverAuthPublicKeyCredential.setType(clientResponse.getType());
@@ -325,7 +327,7 @@ public class AdapterController {
         verifyCredential.setSessionId(sessionId);
         verifyCredential.setOrigin(builder.toString());
 
-        HttpEntity<VerifyCredential> request = new HttpEntity<>(verifyCredential, httpHeaders);
+        final HttpEntity<VerifyCredential> request = new HttpEntity<>(verifyCredential, httpHeaders);
 
         restTemplate.postForObject(authResponseUri, request, VerifyCredentialResult.class);
 
@@ -339,7 +341,7 @@ public class AdapterController {
             return null;
         }
 
-        byte[] digest = Digests.sha256(username.getBytes(StandardCharsets.UTF_8));
+        final byte[] digest = Digests.sha256(username.getBytes(StandardCharsets.UTF_8));
         return Base64.getUrlEncoder().withoutPadding().encodeToString(digest);
     }
 }

--- a/rpserver/src/main/java/com/linecorp/line/auth/fido/fido2/rpserver/model/transport/ServerPublicKeyCredentialCreationOptionsRequest.java
+++ b/rpserver/src/main/java/com/linecorp/line/auth/fido/fido2/rpserver/model/transport/ServerPublicKeyCredentialCreationOptionsRequest.java
@@ -19,6 +19,7 @@ package com.linecorp.line.auth.fido.fido2.rpserver.model.transport;
 import com.linecorp.line.auth.fido.fido2.common.AttestationConveyancePreference;
 import com.linecorp.line.auth.fido.fido2.common.AuthenticatorSelectionCriteria;
 import com.linecorp.line.auth.fido.fido2.common.extension.CredProtect;
+import com.linecorp.line.auth.fido.fido2.common.extension.PRFInputs;
 
 import lombok.Data;
 
@@ -29,4 +30,5 @@ public class ServerPublicKeyCredentialCreationOptionsRequest {
     private AuthenticatorSelectionCriteria authenticatorSelection;
     private AttestationConveyancePreference attestation = AttestationConveyancePreference.none;
     private CredProtect credProtect;
+    private PRFInputs prf;
 }

--- a/rpserver/src/main/java/com/linecorp/line/auth/fido/fido2/rpserver/model/transport/ServerPublicKeyCredentialGetOptionsRequest.java
+++ b/rpserver/src/main/java/com/linecorp/line/auth/fido/fido2/rpserver/model/transport/ServerPublicKeyCredentialGetOptionsRequest.java
@@ -17,6 +17,7 @@
 package com.linecorp.line.auth.fido.fido2.rpserver.model.transport;
 
 import com.linecorp.line.auth.fido.fido2.common.UserVerificationRequirement;
+import com.linecorp.line.auth.fido.fido2.common.extension.PRFInputs;
 
 import lombok.Data;
 
@@ -24,4 +25,5 @@ import lombok.Data;
 public class ServerPublicKeyCredentialGetOptionsRequest {
     private String username;
     private UserVerificationRequirement userVerification;
+    private PRFInputs prf;
 }

--- a/rpserver/src/main/resources/templates/index.html
+++ b/rpserver/src/main/resources/templates/index.html
@@ -215,6 +215,26 @@
         </div>
       </div>
     </div>
+    <hr>
+    <div class="row">
+      <div class="col">
+        <b>Pseudo-random function Extension</b>
+      </div>
+      <div class="col-3">
+        <div class="form-check">
+          <input class="form-check-input" type="checkbox" name="enablePrf" id="enablePrf" value="enablePrf">
+          Specify
+        </div>
+      </div>
+      <div class="col-6">
+        <div class="form-check">
+          <input class="form-control" type="text" name="prfFirst" id="prfFirst" placeholder="Base64url encoded PRF first value">
+        </div>
+        <div class="form-check">
+          <input class="form-control" type="text" name="prfSecond" id="prfSecond" placeholder="Base64url encoded PRF second value">
+        </div>
+      </div>
+    </div>
   </fieldset>
   <!--
   <fieldset class="form-group">


### PR DESCRIPTION
# What is this PR for?
Support PRF extension which is introduced in [Webauthn Level 3](https://www.w3.org/TR/webauthn-3/#prf-extension)

## Overview or reasons
- Make possible to use PRF extension with line-fido2-server 

## Tasks
- Add `PRFValues`, `PRFInputs` and `PRFOutputs` classes that implements PRF extension data structure.
- Make possible to request/response PRF options.
  - Add `prf` field into `AuthenticationExtensionsClientInputs` class.
  - Add `prf` field into `RegOptionRequest` and `AuthOptionRequest` classes.
- Add `prf` field into `AuthenticationExtensionsClientOutputs` class.
- Add PRF options UI and handling into rpserver.
- `final` syntax was added to variables in `AdapterController`.

## Result
- line-fido2-server can handle PRF options.
- Demo can test PRF options
![스크린샷 2025-04-03 15 56 46](https://github.com/user-attachments/assets/9088ad2c-9133-49ae-b3c8-b8ebbfbc82be)
![스크린샷 2025-04-03 15 59 13](https://github.com/user-attachments/assets/ec750028-a2b5-4942-9ccc-835d7ceb2dda)


