### PR TITLE
Update AuthenticatedAt even if the sign counter is zero

### DIFF
--- a/fido2-core/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ResponseServiceImpl.java
+++ b/fido2-core/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ResponseServiceImpl.java
@@ -309,12 +309,13 @@ public class ResponseServiceImpl extends ResponseCommonService implements Respon
         if (authData.getSignCount() != 0 || userKey.getSignCounter() != 0) {
             if (authData.getSignCount() > userKey.getSignCounter()) {
                 // update
-                userKey.setSignCounter(authData.getSignCount());
-                userKeyService.update(userKey);
+                userKeyService.updateSignCounterAndAuthenticatedAt(userKey.getRpId(), userKey.getCredentialId(), authData.getSignCount());
             } else {
                 throw new FIDO2ServerRuntimeException(InternalErrorCode.ASSERTION_SIGNATURE_VERIFICATION_FAIL);
                 // authenticator is may cloned, reject.
             }
+        } else {
+            userKeyService.updateAuthenticatedAt(userKey.getRpId(), userKey.getCredentialId());
         }
     }
 

--- a/fido2-core/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/UserKeyService.java
+++ b/fido2-core/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/UserKeyService.java
@@ -27,7 +27,8 @@ public interface UserKeyService {
     List<UserKey> getWithUserId(String rpId, String userId);
     UserKey getWithCredentialId(String rpId, String credentialId);
     List<UserKey> getWithUserIdAndAaguid(String rpId, String userId, String aaguid);
-    void update(UserKey user);
+    void updateSignCounterAndAuthenticatedAt(String rpId, String credentialId, long signCounter);
+    void updateAuthenticatedAt(String rpId, String credentialId);
     void deleteWithUserId(String rpId, String userId);
     void deleteWithCredentialId(String rpId, String credentialId);
 }

--- a/fido2-demo/base/src/main/java/com/linecorp/line/auth/fido/fido2/base/service/UserKeyServiceImpl.java
+++ b/fido2-demo/base/src/main/java/com/linecorp/line/auth/fido/fido2/base/service/UserKeyServiceImpl.java
@@ -105,10 +105,19 @@ public class UserKeyServiceImpl implements UserKeyService {
 
     @Transactional
     @Override
-    public void update(UserKey user) {
+    public void updateSignCounterAndAuthenticatedAt(String rpId, String credentialId, long signCounter) {
         UserKeyEntity userKeyEntity = userKeyRepository
-                .findByRpEntityIdAndCredentialId(user.getRpId(), user.getCredentialId());
-        userKeyEntity.setSignCounter(user.getSignCounter());
+                .findByRpEntityIdAndCredentialId(rpId, credentialId);
+        userKeyEntity.setSignCounter(signCounter);
+        userKeyEntity.setAuthenticatedTimestamp(new Date());
+        userKeyRepository.save(userKeyEntity);
+    }
+
+    @Transactional
+    @Override
+    public void updateAuthenticatedAt(String rpId, String credentialId) {
+        UserKeyEntity userKeyEntity = userKeyRepository
+                .findByRpEntityIdAndCredentialId(rpId, credentialId);
         userKeyEntity.setAuthenticatedTimestamp(new Date());
         userKeyRepository.save(userKeyEntity);
     }


### PR DESCRIPTION
# What is this PR for?
Update AuthenticatedAt even if sign counter is not to be updated.

## Overview or reasons
- AuthenticatedAt should be updated even if sign counter is 0 (Passkey).

## Tasks
- Remove `update()` from `UserKeyService` interface.
- Add `updateSignCounterAndAuthenticatedAt()` into `UserKeyService` interface.
- Add `updateAuthenticatedAt()` into `UserKeyService` interface.
- Implement these methods into demo.

## Result
- AuthenticatedAt is also updated for authentication using Passkey.