### PR TITLE
Implement session revoke function

### DIFF
--- a/fido2-core/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ResponseServiceImpl.java
+++ b/fido2-core/src/main/java/com/linecorp/line/auth/fido/fido2/server/service/ResponseServiceImpl.java
@@ -59,29 +59,33 @@ public class ResponseServiceImpl extends ResponseCommonService implements Respon
     public RegisterCredentialResult handleAttestation(ServerRegPublicKeyCredential serverPublicKeyCredential, String sessionId,
                                                       String origin, String rpId, TokenBinding tokenBinding) {
 
-        // get session and check existence and served
-        Session session = checkSession(sessionId);
-        ServerAuthenticatorAttestationResponse attestationResponse = serverPublicKeyCredential.getResponse();
+        try {
+            // get session and check existence and served
+            Session session = checkSession(sessionId);
+            ServerAuthenticatorAttestationResponse attestationResponse = serverPublicKeyCredential.getResponse();
 
-        // handle common part
-        log.debug("Handle common part of response");
-        byte[] clientDataHsh = handleCommon("webauthn.create", session.getRegOptionResponse().getChallenge(),
-                attestationResponse.getClientDataJSON(), origin, tokenBinding);
+            // handle common part
+            log.debug("Handle common part of response");
+            byte[] clientDataHsh = handleCommon("webauthn.create", session.getRegOptionResponse().getChallenge(),
+                    attestationResponse.getClientDataJSON(), origin, tokenBinding);
 
-        AttestationObject attestationObject = attestationService.getAttestationObject(attestationResponse);
-        attestationService.attestationObjectValidationCheck(rpId, session.getRegOptionResponse().getAuthenticatorSelection(), attestationObject);
-        AttestationVerificationResult attestationVerificationResult = attestationService.verifyAttestation(clientDataHsh, attestationObject);
+            AttestationObject attestationObject = attestationService.getAttestationObject(attestationResponse);
+            attestationService.attestationObjectValidationCheck(rpId, session.getRegOptionResponse().getAuthenticatorSelection(), attestationObject);
+            AttestationVerificationResult attestationVerificationResult = attestationService.verifyAttestation(clientDataHsh, attestationObject);
 
-        // prepare trust anchors, attestation fmt (from metadata service or trusted source)
-        if (!attestationVerificationResult.isSuccess()) {
-            throw new FIDO2ServerRuntimeException(InternalErrorCode.ATTESTATION_SIGNATURE_VERIFICATION_FAIL);
+            // prepare trust anchors, attestation fmt (from metadata service or trusted source)
+            if (!attestationVerificationResult.isSuccess()) {
+                throw new FIDO2ServerRuntimeException(InternalErrorCode.ATTESTATION_SIGNATURE_VERIFICATION_FAIL);
+            }
+
+            if (attestationVerificationResult.getType() != AttestationType.SELF && attestationVerificationResult.getType() != AttestationType.NONE) {
+                attestationService.verifyAttestationCertificate(attestationObject, attestationVerificationResult);
+            }
+
+            return getRegisterCredentialResult(session.getRegOptionResponse(), attestationResponse.getTransports(), attestationObject.getAuthData(), attestationVerificationResult, serverPublicKeyCredential.getExtensions(), rpId);
+        } finally {
+            sessionService.revokeSession(sessionId);
         }
-
-        if (attestationVerificationResult.getType() != AttestationType.SELF && attestationVerificationResult.getType() != AttestationType.NONE) {
-            attestationService.verifyAttestationCertificate(attestationObject, attestationVerificationResult);
-        }
-
-        return getRegisterCredentialResult(session.getRegOptionResponse(), attestationResponse.getTransports(), attestationObject.getAuthData(), attestationVerificationResult, serverPublicKeyCredential.getExtensions(), rpId);
     }
 
     protected RegisterCredentialResult getRegisterCredentialResult(RegOptionResponse regOptionResponse, List<AuthenticatorTransport> transports, AuthenticatorData authData, AttestationVerificationResult attestationVerificationResult, AuthenticationExtensionsClientOutputs clientExtensions, String rpId) {
@@ -173,24 +177,28 @@ public class ResponseServiceImpl extends ResponseCommonService implements Respon
     public VerifyCredentialResult handleAssertion(ServerAuthPublicKeyCredential serverPublicKeyCredential, String sessionId,
                                                   String origin, String rpId, TokenBinding tokenBinding) {
 
-        Session session = checkSession(sessionId);
-        ServerAuthenticatorAssertionResponse assertionResponse = serverPublicKeyCredential.getResponse();
-        handleCommon("webauthn.get", session.getAuthOptionResponse().getChallenge(),
-                assertionResponse.getClientDataJSON(), origin, tokenBinding);
+        try {
+            Session session = checkSession(sessionId);
+            ServerAuthenticatorAssertionResponse assertionResponse = serverPublicKeyCredential.getResponse();
+            handleCommon("webauthn.get", session.getAuthOptionResponse().getChallenge(),
+                    assertionResponse.getClientDataJSON(), origin, tokenBinding);
 
-        byte[] authDataBytes = Base64.getUrlDecoder().decode(serverPublicKeyCredential.getResponse().getAuthenticatorData());
-        AuthenticatorData authData = getAuthData(authDataBytes);
-        checkCredentialId(serverPublicKeyCredential, session);
+            byte[] authDataBytes = Base64.getUrlDecoder().decode(serverPublicKeyCredential.getResponse().getAuthenticatorData());
+            AuthenticatorData authData = getAuthData(authDataBytes);
+            checkCredentialId(serverPublicKeyCredential, session);
 
-        UserKey userKey = getUserKey(serverPublicKeyCredential, rpId);
-        verifyUserHandle(serverPublicKeyCredential, userKey);
-        verifyAuthDataValues(rpId, session, authData,userKey.getAaguid());
-        verifySignature(serverPublicKeyCredential, authDataBytes, userKey);
+            UserKey userKey = getUserKey(serverPublicKeyCredential, rpId);
+            verifyUserHandle(serverPublicKeyCredential, userKey);
+            verifyAuthDataValues(rpId, session, authData, userKey.getAaguid());
+            verifySignature(serverPublicKeyCredential, authDataBytes, userKey);
 
-        checkSignCounter(authData, userKey);
-        // return authentication processing result
-        log.debug("[Finish handling assertion]");
-        return createVerifyCredentialResult(authData, userKey);
+            checkSignCounter(authData, userKey);
+            // return authentication processing result
+            log.debug("[Finish handling assertion]");
+            return createVerifyCredentialResult(authData, userKey);
+        } finally {
+            sessionService.revokeSession(sessionId);
+        }
     }
 
     protected void checkCredentialId(ServerAuthPublicKeyCredential serverPublicKeyCredential, Session session) {

--- a/fido2-demo/base/src/main/java/com/linecorp/line/auth/fido/fido2/base/service/SessionServiceImpl.java
+++ b/fido2-demo/base/src/main/java/com/linecorp/line/auth/fido/fido2/base/service/SessionServiceImpl.java
@@ -70,13 +70,12 @@ public class SessionServiceImpl implements SessionService {
 
     @Override
     public void revokeSession(String sessionId) {
-        //TODO: TTL NOT WORK
-//        Session session = sessionRepository.getSession(sessionId);
-//        if (session != null) {
-//            session.setServed(true);
-//            sessionRepository.update(session);
-//        } else {
-//            log.warn("no such session with session id: {}", sessionId);
-//        }
+        Session session = sessionRepository.getSession(sessionId);
+        if (session != null) {
+            session.setServed(true);
+            sessionRepository.update(session);
+        } else {
+            log.warn("no such session with session id: {}", sessionId);
+        }
     }
 }


### PR DESCRIPTION
# What is this PR for?

## Overview or reasons
- The `revokeSession()` function is currently not implemented.
- However, if a problem occurs while execution the attestation or assertion, or execution is complete, the session should be revoked to enhance security.

## Tasks
- Activate the revokeSession function (uncomment it)
- Add `try {} finally {}` to the `ResponseServiceImpl.handleAttestation` function and the `ResponseServiceImpl.handleAssertion` function.

## Result
- When an problem occurs during attestation or assertion execution or when execution is completed, the session status changes to the served state.