### PR TITLE
Remove server module, use demo module instead

### DIFF
--- a/run-server.sh
+++ b/run-server.sh
@@ -1,4 +1,4 @@
 #!/bin/sh
 
-SPRING_PROFILES_ACTIVE=conformance ./gradlew  :server:bootrun|tee server.log
+SPRING_PROFILES_ACTIVE=local ./gradlew :demo:bootrun |tee server.log
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -24,7 +24,6 @@ pluginManagement {
 
 rootProject.name = 'fido2'
 
-include 'server'
 include 'fido2-core'
 include 'rpserver'
 include 'common'


### PR DESCRIPTION
# What is this PR for?
This PR removes the unused 'server' module and updates the project to use the 'demo' module instead.

## Overview or reasons
- Removed the no longer used 'server' module from the project configuration
- run-server.sh was still referencing the old 'server' module, causing it to fail to run properly

## Tasks
- Removed 'server' module from settings.gradle
- Updated run-server.sh to reference the 'demo' module

## Result
- Running run-server.sh now starts the 'demo' module
- Project structure is simplified by removing the unused 'server' module