### PR TITLE
feat(MdsV3ServiceImpl): adjusting checkLatestDataExist causing lock

### DIFF
--- a/fido2-demo/base/src/main/java/com/linecorp/line/auth/fido/fido2/base/service/MdsV3ServiceImpl.java
+++ b/fido2-demo/base/src/main/java/com/linecorp/line/auth/fido/fido2/base/service/MdsV3ServiceImpl.java
@@ -92,7 +92,10 @@ public class MdsV3ServiceImpl implements MdsService {
 
     private static void checkLatestDataExist(MetadataTocEntity metadataTocEntity, MetadataBLOBPayload metadataBLOBPayload) throws MdsV3MetadataException {
         // check no and compare with previous
-        if (metadataTocEntity != null && (metadataTocEntity.getId() >= metadataBLOBPayload.getNo())) {
+        // NOTE: must compare metadataTocEntity.getNo() (FIDO Alliance BLOB sequence number)
+        // against metadataBLOBPayload.getNo(), NOT getId() (DB auto-increment PK).
+        // Using getId() causes the sync to be permanently blocked once the PK exceeds the BLOB no.
+        if (metadataTocEntity != null && (metadataTocEntity.getNo() >= metadataBLOBPayload.getNo())) {
             // already up to date
             throw new MdsV3MetadataException(MetadataTOCResult
                     .builder()


### PR DESCRIPTION
# What is this PR for?

## Overview or reasons
- The checkLatestDataExist method was incorrectly using the DB auto-increment PK (getId()) to compare against the FIDO Alliance BLOB sequence number (metadataBLOBPayload.getNo()), causing the MDS metadata sync to be permanently blocked once the PK value exceeded the BLOB sequence number.
- <img width="795" height="405" alt="image" src="https://github.com/user-attachments/assets/841c1e71-b3a3-401b-b9a0-aca3a451e300" />

## Tasks
- Fixed the comparison in checkLatestDataExist to use metadataTocEntity.getNo() (FIDO Alliance BLOB sequence number) instead of getId() (DB auto-increment PK).
- Added a clarifying comment explaining why getNo() must be used over getId().

## Result
- MDS metadata sync now correctly compares BLOB sequence numbers, preventing the sync from being permanently blocked due to a PK/sequence number mismatch.